### PR TITLE
Error when creating a window

### DIFF
--- a/lib/r2d/window.rb
+++ b/lib/r2d/window.rb
@@ -12,7 +12,7 @@ module R2D
       fs = opts[:fullscreen]
 
       if !@@window
-        @@window = GosuWindow.new(w, h)
+        @@window = Adapters::GosuWindow.new(w, h)
         true
       else
         false


### PR DESCRIPTION
Creating a window results in error

``` ruby
   R2D::Window.create
   #=> uninitialized constant R2D::Window::GosuWindow (NameError)
```

The issue seems to be not using `Adapters` namespace infront of `GosuWindow`
